### PR TITLE
chore: recommend extension of volar ID changes

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,4 @@
 
 {
-  "recommendations": ["johnsoncodehk.volar"]
+  "recommendations": ["Vue.volar"]
 }


### PR DESCRIPTION
I cannot find out when Volar's extension ID changed, but open the project will get a notice at vscode startup.

![2C1F9885-D717-42C7-BA69-6A99F82C67DD](https://user-images.githubusercontent.com/2074757/171082897-5af1bb5d-697f-40f8-ac96-b363efc99ba7.png)

Volar new Name(Extension ID) is `Vue.volar`, most of developers should always keep **volar** updating to lastest, so I think it necessary to fix.