### PR TITLE
chore: consider remove deprecated property

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
   },
   "vueCompilerOptions": {
     "target": 3,
-    "jsxTemplates": true
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
 }


### PR DESCRIPTION
Volar 自从 `v1.5.0 pre-release` 开始已经不再需要配置 `jsxTemplate` 属性了，故建议删除废弃的属性配置。vuejs/language-tools#2677