### PR TITLE
fix: Add message-box‘ s overlay style

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import 'uno.css'
 // If you want to use ElMessage, import it.
 import 'element-plus/theme-chalk/src/message.scss'
 import 'element-plus/theme-chalk/src/message-box.scss'
+import 'element-plus/theme-chalk/src/overlay.scss' // the modal class for message box
 
 // if you do not need ssg:
 // import { createApp } from "vue";


### PR DESCRIPTION
- When used with ElTable, the z-index of message box does not take effect. Style conflict
<img width="4460" height="1412" alt="修复后" src="https://github.com/user-attachments/assets/ea7e78a8-8012-46bc-8399-07ea94dee7b0" />
